### PR TITLE
Refactor shoji package to separate nix file

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,19 +18,7 @@
     packagesForSystem = system: let
       pkgs = nixpkgs.legacyPackages.${system};
 
-      shoji = pkgs.buildGoModule rec {
-  	pname = "shoji";
-	name = "shoji";
-	version = "0.0.2";
-
-        src = pkgs.fetchFromGitHub {
-          owner = "AdoPi";
-          repo = "${pname}";
-          rev = "v${version}";
-          hash = "sha256-jGozqQYY/FH+tMPJ+3xxjuZ8DPjb01F0cHKLnrsebls0";
-        };
-	vendorHash = "sha256-uvpMGk0MbjR7kGRL2K1uP1vH30TAuz/ULEjObW6udyA=";
-      };
+      shoji = pkgs.callPackage ./pkgs/shoji.nix { };
 
       shojiInitAgeScript = pkgs.writeShellScriptBin "shoji-init" ''
         #!/usr/bin/env bash

--- a/pkgs/shoji.nix
+++ b/pkgs/shoji.nix
@@ -1,0 +1,27 @@
+{
+  lib
+, buildGoModule
+, fetchFromGitHub
+}:
+
+buildGoModule rec {
+  pname = "shoji";
+  name = "shoji";
+  version = "0.0.2";
+
+  src = fetchFromGitHub {
+    owner = "AdoPi";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-5g0GaUfdndTfPMYQeNPR2mYlc6Y7YoGlVNBodmK3uiY=";
+  };
+
+  vendorHash = "sha256-uvpMGk0MbjR7kGRL2K1uP1vH30TAuz/ULEjObW6udyA=";
+
+  meta = with lib; {
+    description = "SSH Key Management Module";
+    homepage = "https://github.com/AdoPi/shoji";
+    license = licenses.gpl3;
+    maintainers = [ { name = "AdoPi"; email = "adopi.naj@gmail.com"; github = "AdoPi"; } ];
+  };
+}


### PR DESCRIPTION
Require #2 to be merge to work, flake.lock is not up to date since https://github.com/AdoPi/shoji-nix/commit/1a689d1dead1d81295bebfebaa8d98e9eba7fb13 commit

- Refactor shoji package to separate file
- Fix bad hash for shoji package

`nix flake check` run perfectly
`nix build .#shoji` run perfectly too now 