### PR TITLE
Replace types.string with types.str

### DIFF
--- a/modules/home-manager/shoji.nix
+++ b/modules/home-manager/shoji.nix
@@ -54,7 +54,7 @@ in
     };
 
     age-keyfile = mkOption {
-      type = types.string;
+      type = types.str;
       default = "";
       description = "File which contains Age private keys";
     };

--- a/modules/shoji/default.nix
+++ b/modules/shoji/default.nix
@@ -52,7 +52,7 @@ in
       description = "Input Yaml file which will be converted into ssh config file";
     };
     age-keyfile = mkOption {
-      type = types.string;
+      type = types.str;
       default = "/root/.sops/age.key";
       description = "File which contains Age private keys";
     };


### PR DESCRIPTION
`types.string` is deprecated. See the comment from https://github.com/NixOS/nixpkgs/blob/master/lib/types.nix

```
# Deprecated; should not be used because it quietly concatenates
# strings, which is usually not what you want.
```

There are the following options to replace `types.string` with:
- `types.str`
- `types.nonEmptyStr`
- `types.singleLineStr` ("(optionally newline-terminated) single-line string")

I am not 100% sure whether `types.str` is the best replacement but if not, you can change it.